### PR TITLE
Fix theming bug in Markdown sections of the page

### DIFF
--- a/src/pages/blogs/[slug].astro
+++ b/src/pages/blogs/[slug].astro
@@ -38,7 +38,7 @@ const {Content} = await blog.render();
     <script>
         import { toggleMarkdownTheme } from "../../scripts/theme";
 
-        const theme = localStorage.getItem("theme") || "dark";
+        const theme = document.documentElement.dataset.theme;
 
         toggleMarkdownTheme(theme)
     </script>


### PR DESCRIPTION
Rendered markdown blog pages where incorrectly retrieving the theme from the local storage. This did not work on the initial page hit when the user had not previously selected a theme, because only then the theme is saved in local storage. This together with the fact that Layout.astro defaults to the light theme, while the code in [slug].astro defaults to the dark theme created a theming bug, where the background of the page was rendered in light theme, but fonts where rendered in dark theme resulting in light text color on a light background.

The fix for this is using document.documentElement.dataset.theme as the single source of truth for the theme.